### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install 'litellm[proxy]'
 pip install ollama
 
 # Microsoft AutoGen
-pip install pyautogen "pyautogen[retrievechat]" 
+pip install ag2 "ag2[retrievechat]" 
 
 # Microsoft GraphRAG
 pip install graphrag
@@ -36,7 +36,7 @@ conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvi
 
 - litellm[proxy]
 - ollama
-- pyautogen[retrievechat]
+- ag2[retrievechat]
 - tiktoken
 - chainlit
 - graphrag


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
